### PR TITLE
Small hidden bug fixed

### DIFF
--- a/Source/OpenCL/Private/OCLUtility.cpp
+++ b/Source/OpenCL/Private/OCLUtility.cpp
@@ -71,9 +71,8 @@ void FOCLUtility::ArrayFloatToBytes(const TArray<float>& InFloatArray, TArray<ui
 
 void FOCLUtility::ArrayIntToBytes(const TArray<int32>& InIntArray, TArray<uint8>& OutBytes)
 {
-	//int32 have endian problems so must use this safer function
-	OutBytes.Reserve(InIntArray.Num() * sizeof(int32));
-
+	int32 ByteCount = InIntArray.Num() * sizeof(int32);
+	OutBytes.Empty(ByteCount);
 	for (int32 Value : InIntArray)
 	{
 		TArray<uint8> ValueBytes;

--- a/Source/OpenCL/Private/OCLUtility.cpp
+++ b/Source/OpenCL/Private/OCLUtility.cpp
@@ -60,6 +60,9 @@ void FOCLUtility::VectorToBytes(const FVector& InVector, TArray<uint8>& OutBytes
 	OutBytes.Append(FloatArray);
 	FloatToBytes(InVector.Z, FloatArray);
 	OutBytes.Append(FloatArray);
+	//On GPU float3 equals float4. We need 14 bytes size.
+	BytesFromFloat(0.0f, FloatArray);
+	OutBytes.Append(FloatArray);
 }
 
 void FOCLUtility::ArrayFloatToBytes(const TArray<float>& InFloatArray, TArray<uint8>& OutBytes)
@@ -83,9 +86,13 @@ void FOCLUtility::ArrayIntToBytes(const TArray<int32>& InIntArray, TArray<uint8>
 
 void FOCLUtility::ArrayVectorToBytes(const TArray<FVector>& InVectorArray, TArray<uint8>& OutBytes)
 {
-	int32 ByteCount = InVectorArray.Num() * sizeof(FVector);
-	OutBytes.Empty(ByteCount);
-	OutBytes.Append((uint8*)InVectorArray.GetData(), ByteCount);
+	//On GPU float3 equals float4. We need 14 bytes size.
+	OutBytes.Empty();
+	for (FVector Vector : InVectorArray) {
+		TArray<uint8> VectorBytes;
+		VectorToBytes(Vector, VectorBytes);
+		OutBytes.Append(VectorBytes);
+	}
 }
 
 void FOCLUtility::Texture2DToBytes(const UTexture2D* InTexture, TArray<uint8>& OutBytes)
@@ -167,7 +174,8 @@ void FOCLUtility::ArrayIntFromBytes(const TArray<uint8>& InBytes, TArray<int32>&
 
 void FOCLUtility::ArrayVectorFromBytes(const TArray<uint8>& InBytes, TArray<FVector>& OutVectorArray)
 {
-	int32 ValueSize = sizeof(FVector);
+	//On GPU float3 equals float4. We need 14 bytes size.
+	int32 ValueSize = sizeof(float) * 4;
 	OutVectorArray.Reserve(InBytes.Num() / ValueSize);
 
 	TArray<uint8> ValueBytes;

--- a/Source/OpenCL/Private/OCLUtility.cpp
+++ b/Source/OpenCL/Private/OCLUtility.cpp
@@ -60,7 +60,7 @@ void FOCLUtility::VectorToBytes(const FVector& InVector, TArray<uint8>& OutBytes
 	OutBytes.Append(FloatArray);
 	FloatToBytes(InVector.Z, FloatArray);
 	OutBytes.Append(FloatArray);
-	//On GPU float3 equals float4. We need 14 bytes size.
+	//On GPU float3 equals float4. We need 16 bytes size.
 	BytesFromFloat(0.0f, FloatArray);
 	OutBytes.Append(FloatArray);
 }
@@ -86,7 +86,7 @@ void FOCLUtility::ArrayIntToBytes(const TArray<int32>& InIntArray, TArray<uint8>
 
 void FOCLUtility::ArrayVectorToBytes(const TArray<FVector>& InVectorArray, TArray<uint8>& OutBytes)
 {
-	//On GPU float3 equals float4. We need 14 bytes size.
+	//On GPU float3 equals float4. We need 16 bytes size.
 	OutBytes.Empty();
 	for (FVector Vector : InVectorArray) {
 		TArray<uint8> VectorBytes;
@@ -174,7 +174,7 @@ void FOCLUtility::ArrayIntFromBytes(const TArray<uint8>& InBytes, TArray<int32>&
 
 void FOCLUtility::ArrayVectorFromBytes(const TArray<uint8>& InBytes, TArray<FVector>& OutVectorArray)
 {
-	//On GPU float3 equals float4. We need 14 bytes size.
+	//On GPU float3 equals float4. We need 16 bytes size.
 	int32 ValueSize = sizeof(float) * 4;
 	OutVectorArray.Reserve(InBytes.Num() / ValueSize);
 


### PR DESCRIPTION
Referenced output array must be emptied otherwise data will still add over the existing one.